### PR TITLE
urlmatcher: Add page description

### DIFF
--- a/err-urlmatcher/requirements.txt
+++ b/err-urlmatcher/requirements.txt
@@ -1,2 +1,3 @@
 readability-lxml
 requests
+metadata_parser


### PR DESCRIPTION
- Added a way of finding the page description and using it instead of
  the readable summary which is many times wrong.

Signed-off-by: mr.Shu mr@shu.io
